### PR TITLE
fixed library order for static linking

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -111,7 +111,7 @@ endif(CONAN_ADDITIONAL_PLUGINS)''')
         self.copy("*.so", dst="lib", keep_path=False)
 
     def package_info(self):
-        self.cpp_info.libs = ["gpr", "grpc", "grpc++", "grpc_unsecure", "grpc++_unsecure"]
+        self.cpp_info.libs = ["grpc", "grpc++", "grpc_unsecure", "grpc++_unsecure", "gpr"]
         if self.settings.compiler == "Visual Studio":
             self.cpp_info.libs += ["wsock32", "ws2_32"]
 


### PR DESCRIPTION
I was trying to use GRPC via conan in a statically linked binary on Centos 7.

it wouldn't compile because one of the other libraries needs symbols from gpr.

Reordering the libraries fixed my missing symbols.