### PR TITLE
Add protoc_installer as test_package requirement

### DIFF
--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -20,6 +20,7 @@ endif()
 set(protobuf_MODULE_COMPATIBLE TRUE)
 find_package(protoc CONFIG REQUIRED)
 find_package(Protobuf CONFIG REQUIRED)
+message(STATUS "Using protobuf ${protobuf_VERSION}")
 
 set(_PROTOBUF_LIBPROTOBUF protobuf::libprotobuf)
 set(_PROTOBUF_PROTOC $<TARGET_FILE:protobuf::protoc>)

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -18,8 +18,8 @@ endif()
 # Find Protobuf installation
 # Looks for protobuf-config.cmake file installed by Protobuf's cmake installation.
 set(protobuf_MODULE_COMPATIBLE TRUE)
+find_package(protoc CONFIG REQUIRED)
 find_package(Protobuf CONFIG REQUIRED)
-message(STATUS "Using protobuf ${protobuf_VERSION}")
 
 set(_PROTOBUF_LIBPROTOBUF protobuf::libprotobuf)
 set(_PROTOBUF_PROTOC $<TARGET_FILE:protobuf::protoc>)

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -9,6 +9,7 @@ import os
 class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
     generators = "cmake"
+    requires = "protoc_installer/3.6.1@bincrafters/stable",
 
     def build(self):
         cmake = CMake(self)


### PR DESCRIPTION
Hi!

Only your test package requires protoc to generate some files, so only it needs protoc_installer. Also, find_package(protoc) is needed to solve `protobuf::protoc`. 