### PR TITLE
Bin path exported

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -136,6 +136,7 @@ class grpcConan(ConanFile):
         self.copy("*.so", dst="lib", keep_path=False)
 
     def package_info(self):
+        self.env_info.PATH.append(os.path.join(self.package_folder, "bin"))
         self.cpp_info.libs = ["grpc", "grpc++", "grpc_unsecure", "grpc++_unsecure", "gpr", "address_sorting"]
         if self.settings.compiler == "Visual Studio":
             self.cpp_info.libs += ["wsock32", "ws2_32"]


### PR DESCRIPTION
Bin path exported to be able to use grpc_cpp_plugin and other binaries in scripts.
Otherwise conan-grpc package cannot be used properly in other conan packages. (Using `find` is needed to get absolute path to the binary)