### PR TITLE
Split in hybrid default+installer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,9 +19,6 @@ matrix:
    include:
       - stage: installer
         <<: *linux
-        env: CONAN_GCC_VERSIONS=7 CONAN_DOCKER_IMAGE=conanio/gcc7-x86 CONAN_ARCHS=x86 ARCH=x86 CPT_TEST_FOLDER=test_package_installer CONAN_CONANFILE=conanfile_installer.py
-      - stage: installer
-        <<: *linux
         env: CONAN_GCC_VERSIONS=7 CONAN_DOCKER_IMAGE=conanio/gcc7 CONAN_ARCHS=x86_64 ARCH=x86_64 CPT_TEST_FOLDER=test_package_installer CONAN_CONANFILE=conanfile_installer.py
       - stage: installer
         <<: *osx
@@ -29,80 +26,40 @@ matrix:
         env: CONAN_APPLE_CLANG_VERSIONS=11.0 CONAN_ARCHS=x86_64 ARCH=x86_64 CPT_TEST_FOLDER=test_package_installer CONAN_CONANFILE=conanfile_installer.py
       - stage: default
         <<: *linux
-        env: CONAN_GCC_VERSIONS=4.9 CONAN_DOCKER_IMAGE=conanio/gcc49-x86 CONAN_ARCHS=x86
-      - stage: default
-        <<: *linux
         env: CONAN_GCC_VERSIONS=4.9 CONAN_DOCKER_IMAGE=conanio/gcc49 CONAN_ARCHS=x86_64
-      - stage: default
-        <<: *linux
-        env: CONAN_GCC_VERSIONS=5 CONAN_DOCKER_IMAGE=conanio/gcc5-x86 CONAN_ARCHS=x86
       - stage: default
         <<: *linux
         env: CONAN_GCC_VERSIONS=5 CONAN_DOCKER_IMAGE=conanio/gcc5 CONAN_ARCHS=x86_64
       - stage: default
         <<: *linux
-        env: CONAN_GCC_VERSIONS=6 CONAN_DOCKER_IMAGE=conanio/gcc6-x86 CONAN_ARCHS=x86
-      - stage: default
-        <<: *linux
         env: CONAN_GCC_VERSIONS=6 CONAN_DOCKER_IMAGE=conanio/gcc6 CONAN_ARCHS=x86_64
-      - stage: default
-        <<: *linux
-        env: CONAN_GCC_VERSIONS=7 CONAN_DOCKER_IMAGE=conanio/gcc7-x86 CONAN_ARCHS=x86
       - stage: default
         <<: *linux
         env: CONAN_GCC_VERSIONS=7 CONAN_DOCKER_IMAGE=conanio/gcc7 CONAN_ARCHS=x86_64
       - stage: default
         <<: *linux
-        env: CONAN_GCC_VERSIONS=8 CONAN_DOCKER_IMAGE=conanio/gcc8-x86 CONAN_ARCHS=x86
-      - stage: default
-        <<: *linux
         env: CONAN_GCC_VERSIONS=8 CONAN_DOCKER_IMAGE=conanio/gcc8 CONAN_ARCHS=x86_64
-      - stage: default
-        <<: *linux
-        env: CONAN_GCC_VERSIONS=9 CONAN_DOCKER_IMAGE=conanio/gcc9-x86 CONAN_ARCHS=x86
       - stage: default
         <<: *linux
         env: CONAN_GCC_VERSIONS=9 CONAN_DOCKER_IMAGE=conanio/gcc9 CONAN_ARCHS=x86_64
       - stage: default
         <<: *linux
-        env: CONAN_CLANG_VERSIONS=3.9 CONAN_DOCKER_IMAGE=conanio/clang39-x86 CONAN_ARCHS=x86
-      - stage: default
-        <<: *linux
         env: CONAN_CLANG_VERSIONS=3.9 CONAN_DOCKER_IMAGE=conanio/clang39 CONAN_ARCHS=x86_64
-      - stage: default
-        <<: *linux
-        env: CONAN_CLANG_VERSIONS=4.0 CONAN_DOCKER_IMAGE=conanio/clang40-x86 CONAN_ARCHS=x86
       - stage: default
         <<: *linux
         env: CONAN_CLANG_VERSIONS=4.0 CONAN_DOCKER_IMAGE=conanio/clang40 CONAN_ARCHS=x86_64
       - stage: default
         <<: *linux
-        env: CONAN_CLANG_VERSIONS=5.0 CONAN_DOCKER_IMAGE=conanio/clang50-x86 CONAN_ARCHS=x86
-      - stage: default
-        <<: *linux
         env: CONAN_CLANG_VERSIONS=5.0 CONAN_DOCKER_IMAGE=conanio/clang50 CONAN_ARCHS=x86_64
-      - stage: default
-        <<: *linux
-        env: CONAN_CLANG_VERSIONS=6.0 CONAN_DOCKER_IMAGE=conanio/clang60-x86 CONAN_ARCHS=x86
       - stage: default
         <<: *linux
         env: CONAN_CLANG_VERSIONS=6.0 CONAN_DOCKER_IMAGE=conanio/clang60 CONAN_ARCHS=x86_64
       - stage: default
         <<: *linux
-        env: CONAN_CLANG_VERSIONS=7.0 CONAN_DOCKER_IMAGE=conanio/clang7-x86 CONAN_ARCHS=x86
-      - stage: default
-        <<: *linux
         env: CONAN_CLANG_VERSIONS=7.0 CONAN_DOCKER_IMAGE=conanio/clang7 CONAN_ARCHS=x86_64
       - stage: default
         <<: *linux
-        env: CONAN_CLANG_VERSIONS=8 CONAN_DOCKER_IMAGE=conanio/clang8-x86 CONAN_ARCHS=x86
-      - stage: default
-        <<: *linux
         env: CONAN_CLANG_VERSIONS=8 CONAN_DOCKER_IMAGE=conanio/clang8 CONAN_ARCHS=x86_64
-      - stage: default
-        <<: *osx
-        osx_image: xcode8.3
-        env: CONAN_APPLE_CLANG_VERSIONS=8.1
       - stage: default
         <<: *osx
         osx_image: xcode9

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,74 +8,115 @@ linux: &linux
 osx: &osx
    os: osx
    language: generic
-
+stages:
+  - installer
+  - default
 env:
   global:
     CONAN_BUILD_POLICY="missing"  # remove when protobuf installer issue in CI is fixed
 
 matrix:
    include:
-      - <<: *linux
+      - stage: installer
+        <<: *linux
+        env: CONAN_GCC_VERSIONS=7 CONAN_DOCKER_IMAGE=conanio/gcc7-x86 CONAN_ARCHS=x86 ARCH=x86 CPT_TEST_FOLDER=test_package_installer CONAN_CONANFILE=conanfile_installer.py
+      - stage: installer
+        <<: *linux
+        env: CONAN_GCC_VERSIONS=7 CONAN_DOCKER_IMAGE=conanio/gcc7 CONAN_ARCHS=x86_64 ARCH=x86_64 CPT_TEST_FOLDER=test_package_installer CONAN_CONANFILE=conanfile_installer.py
+      - stage: installer
+        <<: *osx
+        osx_image: xcode11
+        env: CONAN_APPLE_CLANG_VERSIONS=11.0 CONAN_ARCHS=x86_64 ARCH=x86_64 CPT_TEST_FOLDER=test_package_installer CONAN_CONANFILE=conanfile_installer.py
+      - stage: default
+        <<: *linux
         env: CONAN_GCC_VERSIONS=4.9 CONAN_DOCKER_IMAGE=conanio/gcc49-x86 CONAN_ARCHS=x86
-      - <<: *linux
+      - stage: default
+        <<: *linux
         env: CONAN_GCC_VERSIONS=4.9 CONAN_DOCKER_IMAGE=conanio/gcc49 CONAN_ARCHS=x86_64
-      - <<: *linux
+      - stage: default
+        <<: *linux
         env: CONAN_GCC_VERSIONS=5 CONAN_DOCKER_IMAGE=conanio/gcc5-x86 CONAN_ARCHS=x86
-      - <<: *linux
+      - stage: default
+        <<: *linux
         env: CONAN_GCC_VERSIONS=5 CONAN_DOCKER_IMAGE=conanio/gcc5 CONAN_ARCHS=x86_64
-      - <<: *linux
+      - stage: default
+        <<: *linux
         env: CONAN_GCC_VERSIONS=6 CONAN_DOCKER_IMAGE=conanio/gcc6-x86 CONAN_ARCHS=x86
-      - <<: *linux
+      - stage: default
+        <<: *linux
         env: CONAN_GCC_VERSIONS=6 CONAN_DOCKER_IMAGE=conanio/gcc6 CONAN_ARCHS=x86_64
-      - <<: *linux
+      - stage: default
+        <<: *linux
         env: CONAN_GCC_VERSIONS=7 CONAN_DOCKER_IMAGE=conanio/gcc7-x86 CONAN_ARCHS=x86
-      - <<: *linux
+      - stage: default
+        <<: *linux
         env: CONAN_GCC_VERSIONS=7 CONAN_DOCKER_IMAGE=conanio/gcc7 CONAN_ARCHS=x86_64
-      - <<: *linux
+      - stage: default
+        <<: *linux
         env: CONAN_GCC_VERSIONS=8 CONAN_DOCKER_IMAGE=conanio/gcc8-x86 CONAN_ARCHS=x86
-      - <<: *linux
+      - stage: default
+        <<: *linux
         env: CONAN_GCC_VERSIONS=8 CONAN_DOCKER_IMAGE=conanio/gcc8 CONAN_ARCHS=x86_64
-      - <<: *linux
+      - stage: default
+        <<: *linux
         env: CONAN_GCC_VERSIONS=9 CONAN_DOCKER_IMAGE=conanio/gcc9-x86 CONAN_ARCHS=x86
-      - <<: *linux
+      - stage: default
+        <<: *linux
         env: CONAN_GCC_VERSIONS=9 CONAN_DOCKER_IMAGE=conanio/gcc9 CONAN_ARCHS=x86_64
-      - <<: *linux
+      - stage: default
+        <<: *linux
         env: CONAN_CLANG_VERSIONS=3.9 CONAN_DOCKER_IMAGE=conanio/clang39-x86 CONAN_ARCHS=x86
-      - <<: *linux
+      - stage: default
+        <<: *linux
         env: CONAN_CLANG_VERSIONS=3.9 CONAN_DOCKER_IMAGE=conanio/clang39 CONAN_ARCHS=x86_64
-      - <<: *linux
+      - stage: default
+        <<: *linux
         env: CONAN_CLANG_VERSIONS=4.0 CONAN_DOCKER_IMAGE=conanio/clang40-x86 CONAN_ARCHS=x86
-      - <<: *linux
+      - stage: default
+        <<: *linux
         env: CONAN_CLANG_VERSIONS=4.0 CONAN_DOCKER_IMAGE=conanio/clang40 CONAN_ARCHS=x86_64
-      - <<: *linux
+      - stage: default
+        <<: *linux
         env: CONAN_CLANG_VERSIONS=5.0 CONAN_DOCKER_IMAGE=conanio/clang50-x86 CONAN_ARCHS=x86
-      - <<: *linux
+      - stage: default
+        <<: *linux
         env: CONAN_CLANG_VERSIONS=5.0 CONAN_DOCKER_IMAGE=conanio/clang50 CONAN_ARCHS=x86_64
-      - <<: *linux
+      - stage: default
+        <<: *linux
         env: CONAN_CLANG_VERSIONS=6.0 CONAN_DOCKER_IMAGE=conanio/clang60-x86 CONAN_ARCHS=x86
-      - <<: *linux
+      - stage: default
+        <<: *linux
         env: CONAN_CLANG_VERSIONS=6.0 CONAN_DOCKER_IMAGE=conanio/clang60 CONAN_ARCHS=x86_64
-      - <<: *linux
+      - stage: default
+        <<: *linux
         env: CONAN_CLANG_VERSIONS=7.0 CONAN_DOCKER_IMAGE=conanio/clang7-x86 CONAN_ARCHS=x86
-      - <<: *linux
+      - stage: default
+        <<: *linux
         env: CONAN_CLANG_VERSIONS=7.0 CONAN_DOCKER_IMAGE=conanio/clang7 CONAN_ARCHS=x86_64
-      - <<: *linux
+      - stage: default
+        <<: *linux
         env: CONAN_CLANG_VERSIONS=8 CONAN_DOCKER_IMAGE=conanio/clang8-x86 CONAN_ARCHS=x86
-      - <<: *linux
+      - stage: default
+        <<: *linux
         env: CONAN_CLANG_VERSIONS=8 CONAN_DOCKER_IMAGE=conanio/clang8 CONAN_ARCHS=x86_64
-      - <<: *osx
+      - stage: default
+        <<: *osx
         osx_image: xcode8.3
         env: CONAN_APPLE_CLANG_VERSIONS=8.1
-      - <<: *osx
+      - stage: default
+        <<: *osx
         osx_image: xcode9
         env: CONAN_APPLE_CLANG_VERSIONS=9.0
-      - <<: *osx
+      - stage: default
+        <<: *osx
         osx_image: xcode9.4
         env: CONAN_APPLE_CLANG_VERSIONS=9.1
-      - <<: *osx
+      - stage: default
+        <<: *osx
         osx_image: xcode10.3
         env: CONAN_APPLE_CLANG_VERSIONS=10.0
-      - <<: *osx
+      - stage: default
+        <<: *osx
         osx_image: xcode11
         env: CONAN_APPLE_CLANG_VERSIONS=11.0
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,31 +7,15 @@ environment:
         - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
           CONAN_VISUAL_VERSIONS: 14
           CONAN_BUILD_TYPES: Release
-          CONAN_ARCHS: x86
-        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-          CONAN_VISUAL_VERSIONS: 14
-          CONAN_BUILD_TYPES: Release
           CONAN_ARCHS: x86_64
         - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
           CONAN_VISUAL_VERSIONS: 14
           CONAN_BUILD_TYPES: Debug
-          CONAN_ARCHS: x86
-        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-          CONAN_VISUAL_VERSIONS: 14
-          CONAN_BUILD_TYPES: Debug
           CONAN_ARCHS: x86_64
         - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
           CONAN_VISUAL_VERSIONS: 15
           CONAN_BUILD_TYPES: Release
-          CONAN_ARCHS: x86
-        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-          CONAN_VISUAL_VERSIONS: 15
-          CONAN_BUILD_TYPES: Release
           CONAN_ARCHS: x86_64
-        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-          CONAN_VISUAL_VERSIONS: 15
-          CONAN_BUILD_TYPES: Debug
-          CONAN_ARCHS: x86
         - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
           CONAN_VISUAL_VERSIONS: 15
           CONAN_BUILD_TYPES: Debug
@@ -39,26 +23,11 @@ environment:
         - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
           CONAN_VISUAL_VERSIONS: 16
           CONAN_BUILD_TYPES: Release
-          CONAN_ARCHS: x86
-        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
-          CONAN_VISUAL_VERSIONS: 16
-          CONAN_BUILD_TYPES: Release
           CONAN_ARCHS: x86_64
         - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
           CONAN_VISUAL_VERSIONS: 16
           CONAN_BUILD_TYPES: Debug
-          CONAN_ARCHS: x86
-        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
-          CONAN_VISUAL_VERSIONS: 16
-          CONAN_BUILD_TYPES: Debug
           CONAN_ARCHS: x86_64
-        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-          CONAN_VISUAL_VERSIONS: 15
-          ARCH: x86
-          CONAN_ARCHS: x86
-          CPT_TEST_FOLDER: test_package_installer
-          CONAN_CONANFILE: conanfile_installer.py
-          CONAN_BUILD_POLICY: outdated
         - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
           CONAN_VISUAL_VERSIONS: 15
           ARCH: x86_64

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -52,6 +52,21 @@ environment:
           CONAN_VISUAL_VERSIONS: 16
           CONAN_BUILD_TYPES: Debug
           CONAN_ARCHS: x86_64
+        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+          CONAN_VISUAL_VERSIONS: 15
+          ARCH: x86
+          CONAN_ARCHS: x86
+          CPT_TEST_FOLDER: test_package_installer
+          CONAN_CONANFILE: conanfile_installer.py
+          CONAN_BUILD_POLICY: outdated
+        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+          CONAN_VISUAL_VERSIONS: 15
+          ARCH: x86_64
+          CONAN_ARCHS: x86_64
+          CPT_TEST_FOLDER: test_package_installer
+          CONAN_CONANFILE: conanfile_installer.py
+          CONAN_BUILD_POLICY: outdated
+
 
 install:
   - set PATH=%PYTHON_HOME%;%PYTHON_HOME%/Scripts/;%PATH%

--- a/conanfile_base.py
+++ b/conanfile_base.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+
+from conans import ConanFile,tools
+from conans.errors import ConanInvalidConfiguration
+import os
+
+class ConanFileBase(ConanFile):
+    name = "grpc"
+    version = "1.23.0"
+    description = "Google's RPC library and framework."
+    topics = ("conan", "grpc", "rpc")
+    url = "https://github.com/inexorgame/conan-grpc"
+    homepage = "https://github.com/grpc/grpc"
+    author = "Bincrafters <bincrafters@gmail.com>"
+    license = "Apache-2.0"
+    exports = ["LICENSE.md","conanfile_base.py"]
+    exports_sources = ["CMakeLists.txt"]
+    generators = "cmake"
+    short_paths = True  # Otherwise some folders go out of the 260 chars path length scope rapidly (on windows)
+
+    protobuf_version="3.9.1"
+
+    _source_subfolder = "source_subfolder"
+    _build_subfolder = "build_subfolder"
+
+    def source(self):
+        sha256 = "86d7552cb79ab9ba7243d86b768952df1907bacb828f5f53b8a740f716f3937b"
+        tools.get("{}/archive/v{}.zip".format(self.homepage, self.version), sha256=sha256)
+        extracted_dir = "grpc-" + self.version
+        os.rename(extracted_dir, self._source_subfolder)
+
+        cmake_path = os.path.join(self._source_subfolder, "CMakeLists.txt")
+        # See #5
+        tools.replace_in_file(cmake_path, "_gRPC_PROTOBUF_LIBRARIES", "CONAN_LIBS_PROTOBUF")

--- a/conanfile_installer.py
+++ b/conanfile_installer.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python
+from conans import CMake
+from conanfile_base import ConanFileBase
+from conans.errors import ConanInvalidConfiguration
+import os
+
+class grpcConan(ConanFileBase):
+    settings="os","arch","compiler","build_type"
+    name ="grpc_installer"
+    version=ConanFileBase.version
+    protobuf_version=ConanFileBase.protobuf_version
+
+    #just to satisfy cmake..
+    build_requires = (
+        "zlib/1.2.11",
+        "openssl/1.0.2s",
+        #TODO make it depend on grpc ??
+        #"@bincrafters/stable"
+        #"protoc_installer/{}@bincrafters/stable".format(ConanFileBase.protobuf_version),
+        #"c-ares/1.15.0"
+        "c-ares/1.15.0@conan/stable"
+    )
+    options = {
+        "build_jwt" : [True,False],
+    }
+
+    default_options = {
+        "build_jwt" : False,
+    }
+
+    plugins=[
+        'grpc_python_plugin',
+        'grpc_php_plugin',
+        'grpc_objective_c_plugin',
+        'grpc_node_plugin',
+        'grpc_csharp_plugin',
+        'grpc_cpp_plugin'
+    ]
+
+    def requirements(self):
+        self.requires.add("protobuf/{}@bincrafters/stable".format(ConanFileBase.protobuf_version))
+        self.requires.add("protoc_installer/{}@bincrafters/stable".format(ConanFileBase.protobuf_version))
+
+
+    def configure(self):
+        if self.options.build_jwt:
+            plugins.append('grpc_verify_jwt','grpc_create_jwt')
+        if self.settings.os == "Windows" and self.settings.compiler == "Visual Studio":
+            del self.options.fPIC
+            compiler_version = int(str(self.settings.compiler.version))
+            if compiler_version < 14:
+                raise ConanInvalidConfiguration("gRPC can only be built with Visual Studio 2015 or higher.")
+
+    def _configure_cmake(self):
+        cmake = CMake(self)
+
+        # This doesn't work yet as one would expect, because the install target builds everything
+        # and we need the install target because of the generated CMake files
+        #
+        #   enable_mobile=False # Enables iOS and Android support
+        #   non_cpp_plugins=False # Enables plugins such as --java-out and --py-out (if False, only --cpp-out is possible)
+        #
+        # cmake.definitions['CONAN_ADDITIONAL_PLUGINS'] = "ON" if self.options.build_csharp_ext else "OFF"
+        #
+        # Doesn't work yet for the same reason as above
+        #
+        # cmake.definitions['CONAN_ENABLE_MOBILE'] = "ON" if self.options.build_csharp_ext else "OFF"
+
+
+        cmake.definitions['gRPC_BUILD_CODEGEN'] = "ON"
+        cmake.definitions['gRPC_BUILD_CSHARP_EXT'] = "OFF"
+        cmake.definitions['gRPC_BUILD_TESTS'] = "OFF"
+
+        # We need the generated cmake/ files (bc they depend on the list of targets, which is dynamic)
+        cmake.definitions['gRPC_INSTALL'] = "ON"
+        # cmake.definitions['CMAKE_INSTALL_PREFIX'] = self._build_subfolder
+
+        # tell grpc to use the find_package versions
+        cmake.definitions['gRPC_CARES_PROVIDER'] = "package"
+        cmake.definitions['gRPC_ZLIB_PROVIDER'] = "package"
+        cmake.definitions['gRPC_SSL_PROVIDER'] = "package"
+        cmake.definitions['gRPC_PROTOBUF_PROVIDER'] = "package"
+
+        # Workaround for https://github.com/grpc/grpc/issues/11068
+        cmake.definitions['gRPC_GFLAGS_PROVIDER'] = "none"
+        cmake.definitions['gRPC_BENCHMARK_PROVIDER'] = "none"
+
+        # Compilation on minGW GCC requires to set _WIN32_WINNTT to at least 0x600
+        # https://github.com/grpc/grpc/blob/109c570727c3089fef655edcdd0dd02cc5958010/include/grpc/impl/codegen/port_platform.h#L44
+        if self.settings.os == "Windows" and self.settings.compiler == "gcc":
+            cmake.definitions["CMAKE_CXX_FLAGS"] = "-D_WIN32_WINNT=0x600"
+            cmake.definitions["CMAKE_C_FLAGS"] = "-D_WIN32_WINNT=0x600"
+
+        cmake.configure(build_folder=self._build_subfolder)
+        return cmake
+
+    def build(self):
+        cmake = self._configure_cmake()
+        #does conan support multiple targets ??
+        for plugs in self.plugins:
+            cmake.build(target=plugs)
+
+    def package(self):
+        self.copy("*", dst="bin", src="build_subfolder/bin")
+
+    def package_id(self):
+        del self.info.settings.compiler
+        del self.info.settings.arch
+        self.info.include_build_settings()
+
+    def package_info(self):
+        self.env_info.PATH.append(os.path.join(self.package_folder, "bin"))

--- a/grpc.patch
+++ b/grpc.patch
@@ -1,0 +1,106 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 5ee805b485..100323ee45 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -192,12 +192,8 @@ function(protobuf_generate_grpc_cpp)
+     get_filename_component(REL_DIR ${REL_FIL} DIRECTORY)
+     set(RELFIL_WE "${REL_DIR}/${FIL_WE}")
+ 
+-    #if cross-compiling, find host plugin
+-    if(CMAKE_CROSSCOMPILING)
+-        find_program(_gRPC_CPP_PLUGIN grpc_cpp_plugin)
+-    else()
+-        set(_gRPC_CPP_PLUGIN $<TARGET_FILE:grpc_cpp_plugin>)
+-    endif()
++    #TODO get target from conanbuildinfo.cmake
++    find_program(_gRPC_CPP_PLUGIN grpc_cpp_plugin)
+ 
+     add_custom_command(
+       OUTPUT "${_gRPC_PROTO_GENS_DIR}/${RELFIL_WE}.grpc.pb.cc"
+@@ -211,7 +207,7 @@ function(protobuf_generate_grpc_cpp)
+            --plugin=protoc-gen-grpc=${_gRPC_CPP_PLUGIN}
+            ${_protobuf_include_path}
+            ${REL_FIL}
+-      DEPENDS ${ABS_FIL} ${_gRPC_PROTOBUF_PROTOC} grpc_cpp_plugin
++      DEPENDS ${ABS_FIL} ${_gRPC_PROTOBUF_PROTOC} ${_gRPC_CPP_PLUGIN} #TODO add GRPC_INSTALLER dependency
+       WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+       COMMENT "Running gRPC C++ protocol buffer compiler on ${FIL}"
+       VERBATIM)
+@@ -3477,7 +3473,6 @@ endif (gRPC_BUILD_CODEGEN)
+ 
+ endif (gRPC_BUILD_TESTS)
+ 
+-if (gRPC_BUILD_CODEGEN)
+ add_library(grpc++_error_details
+   ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/status/status.pb.cc
+   ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/status/status.grpc.pb.cc
+@@ -3532,9 +3527,6 @@ foreach(_hdr
+     DESTINATION "${gRPC_INSTALL_INCLUDEDIR}/${_path}"
+   )
+ endforeach()
+-endif (gRPC_BUILD_CODEGEN)
+-
+-if (gRPC_BUILD_CODEGEN)
+ 
+ if (gRPC_INSTALL)
+   install(TARGETS grpc++_error_details EXPORT gRPCTargets
+@@ -3544,7 +3536,6 @@ if (gRPC_INSTALL)
+   )
+ endif()
+ 
+-endif (gRPC_BUILD_CODEGEN)
+ if (gRPC_BUILD_TESTS)
+ 
+ if (gRPC_BUILD_CODEGEN)
+@@ -3610,7 +3601,6 @@ endif (gRPC_BUILD_CODEGEN)
+ 
+ endif (gRPC_BUILD_TESTS)
+ 
+-if (gRPC_BUILD_CODEGEN)
+ add_library(grpc++_reflection
+   src/cpp/ext/proto_server_reflection.cc
+   src/cpp/ext/proto_server_reflection_plugin.cc
+@@ -3666,9 +3656,6 @@ foreach(_hdr
+     DESTINATION "${gRPC_INSTALL_INCLUDEDIR}/${_path}"
+   )
+ endforeach()
+-endif (gRPC_BUILD_CODEGEN)
+-
+-if (gRPC_BUILD_CODEGEN)
+ 
+ if (gRPC_INSTALL)
+   install(TARGETS grpc++_reflection EXPORT gRPCTargets
+@@ -3678,7 +3665,6 @@ if (gRPC_INSTALL)
+   )
+ endif()
+ 
+-endif (gRPC_BUILD_CODEGEN)
+ if (gRPC_BUILD_TESTS)
+ 
+ add_library(grpc++_test_config
+@@ -4674,7 +4660,6 @@ if (gRPC_INSTALL)
+ endif()
+ 
+ 
+-if (gRPC_BUILD_CODEGEN)
+ add_library(grpcpp_channelz
+   src/cpp/server/channelz/channelz_service.cc
+   src/cpp/server/channelz/channelz_service_plugin.cc
+@@ -4729,9 +4714,6 @@ foreach(_hdr
+     DESTINATION "${gRPC_INSTALL_INCLUDEDIR}/${_path}"
+   )
+ endforeach()
+-endif (gRPC_BUILD_CODEGEN)
+-
+-if (gRPC_BUILD_CODEGEN)
+ 
+ if (gRPC_INSTALL)
+   install(TARGETS grpcpp_channelz EXPORT gRPCTargets
+@@ -4741,7 +4723,6 @@ if (gRPC_INSTALL)
+   )
+ endif()
+ 
+-endif (gRPC_BUILD_CODEGEN)
+ if (gRPC_BUILD_TESTS)
+ 
+ if (gRPC_BUILD_CODEGEN)

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -31,7 +31,8 @@ find_package(gRPC CONFIG REQUIRED)
 message(STATUS "Using gRPC ${gRPC_VERSION}")
 
 set(_GRPC_GRPCPP_UNSECURE gRPC::grpc++_unsecure)
-set(_GRPC_CPP_PLUGIN_EXECUTABLE $<TARGET_FILE:gRPC::grpc_cpp_plugin>)
+#todo fix packaging of grpc_installer
+find_program(_GRPC_CPP_PLUGIN_EXECUTABLE grpc_cpp_plugin)
 
 # Proto file
 get_filename_component(hw_proto "helloworld.proto" ABSOLUTE)

--- a/test_package_installer/CMakeLists.txt
+++ b/test_package_installer/CMakeLists.txt
@@ -1,0 +1,63 @@
+cmake_minimum_required(VERSION 3.1.5)
+project(test_package)
+
+set(CMAKE_VERBOSE_MAKEFILE TRUE)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup()
+
+if(NOT MSVC)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+else()
+  add_definitions(-D_WIN32_WINNT=0x600)
+endif()
+
+find_package(protoc CONFIG REQUIRED)
+
+message(STATUS "Using protobuf ${protobuf_VERSION}")
+
+#for target file protoc
+set(PROTOS helloworld.proto)
+
+# Proto file
+get_filename_component(hw_proto "helloworld.proto" ABSOLUTE)
+get_filename_component(hw_proto_path "${hw_proto}" PATH)
+
+include_directories(${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
+
+
+#WHY isnt this working ?
+if(protobuf_MODULE_COMPATIBLE)
+  protobuf_generate_cpp(PROTO_SRCS PROTO_HDRS ${PROTOS})
+else()
+  message("protobuf module is incompatible")
+endif()
+#PROTOBUF_GENERATE_CPP(PROTO_SRCS PROTO_HDRS ${PROTOS})
+#generate protobuf stuff
+#protobuf_generate_cpp(PROTO_SRCS PROTO_HDRS ${PROTOS})
+#generate grpc stuff
+#grpc_generate_cpp(GRPC_SRCS GRPC_HDRS ${CMAKE_CURRENT_BINARY_DIR} ${PROTOS})
+find_program(_GRPC_CPP_PLUGIN_EXECUTABLE grpc_cpp_plugin)
+# Generated sources
+set(hw_proto_srcs "${CMAKE_CURRENT_BINARY_DIR}/helloworld.pb.cc")
+set(hw_proto_hdrs "${CMAKE_CURRENT_BINARY_DIR}/helloworld.pb.h")
+set(hw_grpc_srcs "${CMAKE_CURRENT_BINARY_DIR}/helloworld.grpc.pb.cc")
+set(hw_grpc_hdrs "${CMAKE_CURRENT_BINARY_DIR}/helloworld.grpc.pb.h")
+
+set(GEN_SRCS ${hw_proto_srcs} ${hw_proto_hdrs} ${hw_grpc_srcs} ${hw_grpc_hdrs})
+add_custom_command(
+  OUTPUT ${GEN_SRCS}
+  BYPRODUCTS ${GEN_SRCS}
+  COMMAND $<TARGET_FILE:protobuf::protoc>
+  ARGS --grpc_out "${CMAKE_CURRENT_BINARY_DIR}"
+       --cpp_out "${CMAKE_CURRENT_BINARY_DIR}"
+        -I "${hw_proto_path}"
+        --plugin=protoc-gen-grpc=${_GRPC_CPP_PLUGIN_EXECUTABLE}
+        ${PROTOS}
+  DEPENDS ${ABS_FIL} $<TARGET_FILE:protobuf::protoc> ${_GRPC_CPP_PLUGIN_EXECUTABLE}
+  COMMENT "Running C++ gRPC compiler on ${PROTOS}"
+  VERBATIM )
+
+add_custom_target(dummy DEPENDS ${GEN_SRCS})
+add_executable(greeter_client dummy.c)
+add_dependencies(greeter_client dummy )

--- a/test_package_installer/conanfile.py
+++ b/test_package_installer/conanfile.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from conans import tools,ConanFile,CMake
+import os
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    version="1.23.0"
+    generators = "cmake"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def imports(self):
+        self.copy("*", "bin", "bin")
+
+    def test(self):
+        if not tools.cross_building(self.settings):
+            bin_path = os.path.join(".", "bin", "greeter_client")
+            self.run(bin_path, run_environment=True)

--- a/test_package_installer/dummy.c
+++ b/test_package_installer/dummy.c
@@ -1,0 +1,4 @@
+int main()
+{
+  return 0;
+}

--- a/test_package_installer/helloworld.proto
+++ b/test_package_installer/helloworld.proto
@@ -1,0 +1,38 @@
+// Copyright 2015 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "io.grpc.examples.helloworld";
+option java_outer_classname = "HelloWorldProto";
+option objc_class_prefix = "HLW";
+
+package helloworld;
+
+// The greeting service definition.
+service Greeter {
+  // Sends a greeting
+  rpc SayHello (HelloRequest) returns (HelloReply) {}
+}
+
+// The request message containing the user's name.
+message HelloRequest {
+  string name = 1;
+}
+
+// The response message containing the greetings
+message HelloReply {
+  string message = 1;
+}


### PR DESCRIPTION
I tried using the FindPackage(gRPC) but that adds -lprotoc and -lprotobuf which fail. However with all the libs included i was able to build the basic example with some modifications.. However i would prefer to be able to use each lib specifically instead of CONAN_PKG::grpc 

I added the gRPCModule.cmake  which includes the wrapper around the grpc as in https://github.com/IvanSafonov/grpc-cmake-example however some modifications where needed to make it work. Adjusted the test package accordingly

