### PR TITLE
Fix MinGW shared library build in Testing/1.25.0

### DIFF
--- a/001-fix-mingw-linking.patch
+++ b/001-fix-mingw-linking.patch
@@ -1,0 +1,28 @@
+ CMakeLists.txt | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 0693fe1f9a..57a60a700a 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -109,6 +109,11 @@ if (MSVC)
+   # TODO(jtattermusch): needed to build boringssl with VS2017, revisit later
+   set(_gRPC_C_CXX_FLAGS "${_gRPC_C_CXX_FLAGS} /wd4987 /wd4774 /wd4819 /wd4996 /wd4619")
+ endif()
++
++if (MINGW)
++  add_definitions(-D_WIN32_WINNT=0x600)
++endif()
++
+ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${_gRPC_C_CXX_FLAGS}")
+ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${_gRPC_C_CXX_FLAGS}")
+ 
+@@ -155,7 +160,7 @@ elseif(UNIX)
+   set(_gRPC_ALLTARGETS_LIBRARIES ${CMAKE_DL_LIBS} rt m pthread)
+ endif()
+ 
+-if(WIN32 AND MSVC)
++if(WIN32)
+   set(_gRPC_BASELIB_LIBRARIES wsock32 ws2_32)
+ endif()
+ 

--- a/conanfile.py
+++ b/conanfile.py
@@ -55,6 +55,7 @@ class grpcConan(ConanFile):
 
         # See #5
         tools.replace_in_file(cmake_path, "_gRPC_PROTOBUF_LIBRARIES", "CONAN_LIBS_PROTOBUF")
+        tools.patch(base_path=self._source_subfolder, patch_file="001-fix-mingw-linking.patch")
 
         # Parts which should be options:
         # grpc_cronet


### PR DESCRIPTION
This pull request fixes the build of MinGW shared grpc library.

I added a patch, that fixes the grpc `CMakeLists.txt` file to add the two missing libraries to the MinGW build - this fixes the linker error for MinGW shared grpc library. I also submitted this patch to grpc project directly to fix this issue: https://github.com/grpc/grpc/pull/21720

Another problem was, that the grpc build runs some executables that depend on protobuf and zlib Dlls which where not in the library search path (the PATH variable on Windows). This caused the following build error:

```bash
[ 98%] Running gRPC C++ protocol buffer compiler on src/proto/grpc/status/status.proto
[ 98%] Running gRPC C++ protocol buffer compiler on src/proto/grpc/reflection/v1alpha/reflection.proto
[ 98%] Running gRPC C++ protocol buffer compiler on src/proto/grpc/channelz/channelz.proto
--grpc_out: protoc-gen-grpc: Plugin failed with status code 3221225781.
--grpc_out: protoc-gen-grpc: Plugin failed with status code 3221225781.
--grpc_out: protoc-gen-grpc: Plugin failed with status code 3221225781.
mingw32-make.exe[2]: *** [source_subfolder\CMakeFiles\grpc++_reflection.dir\build.make:63: gens/src/proto/grpc/reflection/v1alpha/reflection.grpc.pb.cc] Error 1
mingw32-make.exe[2]: *** [source_subfolder\CMakeFiles\grpc++_error_details.dir\build.make:63: gens/src/proto/grpc/status/status.grpc.pb.cc] Error 1
mingw32-make.exe[2]: *** [source_subfolder\CMakeFiles\grpcpp_channelz.dir\build.make:63: gens/src/proto/grpc/channelz/channelz.grpc.pb.cc] Error 1
mingw32-make.exe[1]: *** [CMakeFiles\Makefile2:491: source_subfolder/CMakeFiles/grpc++_error_details.dir/all] Error 2
mingw32-make.exe[1]: *** Waiting for unfinished jobs....
mingw32-make.exe[1]: *** [CMakeFiles\Makefile2:522: source_subfolder/CMakeFiles/grpc++_reflection.dir/all] Error 2
mingw32-make.exe[1]: *** [CMakeFiles\Makefile2:580: source_subfolder/CMakeFiles/grpcpp_channelz.dir/all] Error 2
mingw32-make.exe: *** [Makefile:129: all] Error 2
grpc/1.25.0@inexorgame/stable:
grpc/1.25.0@inexorgame/stable: ERROR: Package 'd56ce5c99195ffb578669358c98aa6663a744e4b' build failed
grpc/1.25.0@inexorgame/stable: WARN: Build folder C:\.conan\0ede61\1
ERROR: grpc/1.25.0@inexorgame/stable: Error in build() method, line 120
        cmake.build()
        ConanException: Error 2 while executing C:\CodingXP\cmake-3.16.2-win64-x64\bin\cmake.exe --build C:\.conan\0ede61\1\build_subfolder -- -j8
```

I fixed this problem by adding the protobuf and zlib bin paths to the PATH variable. I tested this only for MinGW but normally this problem should also occur for MSVC builds. The patch fixes this only for MinGW. This problem does not occur for static builds, because no DLLs are required.

Because the shared library build works now, at least for MinGW, I enabled the shared option of the library. We use the library in a project here and so far it works.

Just in case it matters - this is my Conan profile for testing these change:
```
[settings]
os=Windows
os_build=Windows
arch=x86
arch_build=x86_64
build_type=Release
compiler=gcc
compiler.libcxx=libstdc++
compiler.version=7
compiler.exception=dwarf2
compiler.threads=posix
[options]

[build_requires]

[env]
PATH=[/c/CodingXP/mingw730_32/bin/]
CC=C:/CodingXP/mingw730_32/bin/gcc.exe
CXX=C:/CodingXP/mingw730_32/bin/g++.exe
AR=C:/CodingXP/mingw730_32/bin/ar.exe
RANLIB=C:/CodingXP/mingw730_32/bin/ranlib.exe
CONAN_CMAKE_PROGRAM=C:\CodingXP\cmake-3.16.2-win64-x64\bin\cmake.exe
```

This was the command line for building grpc including all dependencies:

```bash
conan install grpc/1.25.0@inexorgame/stable -o *:shared=True -b missing
```