### PR TITLE
Add GCC 9 support

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -12,8 +12,8 @@ class grpcConan(ConanFile):
     homepage = "https://github.com/grpc/grpc"
     license = "Apache-2.0"
     exports_sources = ["CMakeLists.txt"]
-    generators = "cmake"
-    short_paths = True  # Otherwise some folders go out of the 260 chars path length scope rapidly (on windows)
+    generators = "cmake", "cmake_find_package_multi"
+    short_paths = True
 
     settings = "os", "arch", "compiler", "build_type"
     options = {
@@ -36,7 +36,7 @@ class grpcConan(ConanFile):
         "openssl/1.0.2t",
         "protobuf/3.9.1@bincrafters/stable",
         "protoc_installer/3.9.1@bincrafters/stable",
-        "c-ares/1.15.0@conan/stable"
+        "c-ares/1.15.0"
     )
 
     def configure(self):
@@ -55,6 +55,10 @@ class grpcConan(ConanFile):
 
         # See #5
         tools.replace_in_file(cmake_path, "_gRPC_PROTOBUF_LIBRARIES", "CONAN_LIBS_PROTOBUF")
+
+        # cmake_find_package_multi is producing a c-ares::c-ares target, grpc is looking for c-ares::cares
+        tools.replace_in_file(
+            os.path.join(self._source_subfolder, "cmake", "cares.cmake"), "c-ares::cares", "c-ares::c-ares")
 
         # Parts which should be options:
         # grpc_cronet

--- a/conanfile.py
+++ b/conanfile.py
@@ -115,6 +115,9 @@ class grpcConan(ConanFile):
             cmake.definitions["CMAKE_CXX_FLAGS"] = "-D_WIN32_WINNT=0x600"
             cmake.definitions["CMAKE_C_FLAGS"] = "-D_WIN32_WINNT=0x600"
 
+        if self.settings.os == "Windows" and self.settings.compiler == "Visual Studio" and not self.options["protobuf"].shared:
+            cmake.definitions["Protobuf_USE_STATIC_LIBS"] = "ON"
+
         cmake.configure(build_folder=self._build_subfolder)
         return cmake
 

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -7,7 +7,7 @@ import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake"
+    generators = "cmake", "cmake_find_package_multi"
 
     def build(self):
         cmake = CMake(self)


### PR DESCRIPTION
Should switch c-ares/1.15.0@conan/stable to new c-ares/1.15.0 to get new compilers support.

I notice some newer branches has already updated.