### PR TITLE
Add components

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -2,6 +2,8 @@ from conans import ConanFile, CMake, tools
 from conans.errors import ConanInvalidConfiguration
 from conans.tools import Version
 import os
+import re
+import json
 
 
 class grpcConan(ConanFile):
@@ -18,6 +20,7 @@ class grpcConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
     # TODO: Add shared option
     options = {
+        "shared": [True, False],
         "fPIC": [True, False],
         "build_codegen": [True, False],
         "build_csharp_ext": [True, False],
@@ -30,6 +33,7 @@ class grpcConan(ConanFile):
         "build_ruby_plugin": [True, False]
     }
     default_options = {
+        "shared": False,
         "fPIC": True,
         "build_codegen": True,
         "build_csharp_ext": False,
@@ -62,6 +66,12 @@ class grpcConan(ConanFile):
             if compiler_version < 14:
                 raise ConanInvalidConfiguration("gRPC can only be built with Visual Studio 2015 or higher.")
 
+    def config_options(self):
+        pass
+        # if protobuf not compiled with 'lite' library, delete use_proto_lite
+        # if not self.options["protobuf"].lite:
+        #    del self.options.use_proto_lite
+
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])
         extracted_dir = self.name + "-" + self.version
@@ -85,6 +95,7 @@ class grpcConan(ConanFile):
 
         cmake.definitions["gRPC_BUILD_CODEGEN"] = "ON" if self.options.build_codegen else "OFF"
         cmake.definitions["gRPC_BUILD_CSHARP_EXT"] = "ON" if self.options.build_csharp_ext else "OFF"
+        cmake.definitions['gRPC_BACKWARDS_COMPATIBILITY_MODE'] = "OFF"
         cmake.definitions["gRPC_BUILD_TESTS"] = "OFF"
 
         # We need the generated cmake/ files (bc they depend on the list of targets, which is dynamic)
@@ -97,7 +108,10 @@ class grpcConan(ConanFile):
         cmake.definitions["gRPC_ZLIB_PROVIDER"] = "package"
         cmake.definitions["gRPC_SSL_PROVIDER"] = "package"
         cmake.definitions["gRPC_PROTOBUF_PROVIDER"] = "package"
+        cmake.definitions['gRPC_PROTOBUF_PACKAGE_TYPE'] = "MODULE"
         cmake.definitions["gRPC_RE2_PROVIDER"] = "package"
+
+        cmake.definitions['gRPC_USE_PROTO_LITE'] = "OFF"
 
         cmake.definitions["gRPC_BUILD_GRPC_CPP_PLUGIN"] = self.options.build_cpp_plugin
         cmake.definitions["gRPC_BUILD_GRPC_CSHARP_PLUGIN"] = self.options.build_csharp_plugin
@@ -126,38 +140,75 @@ class grpcConan(ConanFile):
         cmake = self._configure_cmake()
         cmake.install()
 
-        # tools.rmdir(os.path.join(self.package_folder, "lib", "cmake"))
-        # tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
-        tools.rmdir(os.path.join(self.package_folder, "share"))
-    
+        cmake_folder = os.path.join(self.package_folder, "lib", "cmake")
+        tools.rmdir(cmake_folder)
+
     def package_info(self):
         bindir = os.path.join(self.package_folder, "bin")
         self.output.info("Appending PATH environment variable: {}".format(bindir))
         self.env_info.PATH.append(bindir)
 
+        system_libs = []
+        if self.settings.os == "Macos" or self.settings.os == "iOS":
+            system_libs = ["dl", "m", "pthread"]
+        elif self.settings.os == "Linux":
+            system_libs = ["dl", "m", "rt", "pthread"]
+        elif self.settings.os == "Android":
+            system_libs = ["dl", "m"]
+        elif self.settings.os == "Windows":
+            system_libs = ["wsock32", "ws2_32", "crypt32"]
+
         self.cpp_info.names["cmake_find_package"] = "gRPC"
         self.cpp_info.names["cmake_find_package_multi"] = "gRPC"
 
-        self.cpp_info.libs = [
-            "grpc++_unsecure",
-            "grpc++_reflection",
-            "grpc++_error_details",
-            "grpc++",
-            "grpc_unsecure",
-            "grpc_plugin_support",
-            "grpc_cronet",
-            "grpcpp_channelz",
-            "grpc",
-            "gpr",
-            "address_sorting",
-            "upb",
-        ]
+        self.cpp_info.components["address_sorting"].libs = ["address_sorting"]
+        self.cpp_info.components["address_sorting"].system_libs = system_libs
 
-        if self.settings.os == "Windows":
-            self.cpp_info.system_libs = ["wsock32", "ws2_32", "crypt32"]
-        if self.settings.os == "Linux":
-            self.cpp_info.system_libs = ["dl", "rt", "m", "pthread"]
-        if tools.is_apple_os(self.settings.os):
-            self.cpp_info.system_libs = ["m", "pthread"]
+        self.cpp_info.components["upb"].libs = ["upb"]
+        self.cpp_info.components["upb"].system_libs = system_libs
+
+        self.cpp_info.components["gpr"].libs = ["gpr"]
+        self.cpp_info.components["gpr"].system_libs = system_libs
         if self.settings.os == "Android":
-            self.cpp_info.system_libs = ["m"]
+            self.cpp_info.components["gpr"].system_libs.append("log")
+        self.cpp_info.components["gpr"].requires = ["abseil::absl_time", "abseil::absl_synchronization", "abseil::absl_strings", "abseil::absl_str_format", "abseil::absl_memory", "abseil::absl_base"]
+
+        self.cpp_info.components["libgrpc"].libs = ["grpc"]
+        self.cpp_info.components["libgrpc"].system_libs = system_libs
+        self.cpp_info.components["libgrpc"].frameworks = ["CoreFoundation"]
+        self.cpp_info.components["libgrpc"].requires = ["openssl::ssl", "openssl::crypto", "zlib::zlib", "c-ares::cares", "re2::re2", "address_sorting", "upb", "gpr", "abseil::absl_optional", "abseil::absl_strings", "abseil::absl_status", "abseil::absl_inlined_vector", "abseil::absl_flat_hash_set"]
+
+        self.cpp_info.components["grpc_plugin_support"].libs = ["grpc_plugin_support"]
+        self.cpp_info.components["grpc_plugin_support"].system_libs = system_libs
+        self.cpp_info.components["grpc_plugin_support"].requires = ["protobuf::libprotoc", "protobuf::libprotobuf"]
+
+        self.cpp_info.components["grpc_unsecure"].libs = ["grpc_unsecure"]
+        self.cpp_info.components["grpc_unsecure"].system_libs = system_libs
+        self.cpp_info.components["grpc_unsecure"].frameworks = ["CoreFoundation"]
+        self.cpp_info.components["grpc_unsecure"].requires = ["zlib::zlib", "c-ares::cares", "re2::re2", "address_sorting", "upb", "abseil::absl_optional", "abseil::absl_strings", "abseil::absl_status", "abseil::absl_inlined_vector"]
+
+        self.cpp_info.components["grpc++"].libs = ["grpc++"]
+        self.cpp_info.components["grpc++"].system_libs = system_libs
+        self.cpp_info.components["grpc++"].requires = ["protobuf::libprotobuf", "libgrpc", "gpr", "address_sorting", "upb"]
+
+        self.cpp_info.components["grpcpp_channelz"].libs = ["grpcpp_channelz"]
+        self.cpp_info.components["grpcpp_channelz"].system_libs = system_libs
+        self.cpp_info.components["grpcpp_channelz"].requires = ["protobuf::libprotobuf", "grpc++", "libgrpc", "gpr", "upb"]
+
+        self.cpp_info.components["grpc++_alts"].libs = ["grpc++_alts"]
+        self.cpp_info.components["grpc++_alts"].system_libs = system_libs
+        self.cpp_info.components["grpc++_alts"].requires = ["protobuf::libprotobuf", "grpc++", "libgrpc", "gpr", "upb"]
+
+        self.cpp_info.components["grpc++_error_details"].libs = ["grpc++_error_details"]
+        self.cpp_info.components["grpc++_error_details"].system_libs = system_libs
+        self.cpp_info.components["grpc++_error_details"].requires = ["protobuf::libprotobuf", "grpc++", "libgrpc", "gpr", "upb"]
+
+        self.cpp_info.components["grpc++_reflection"].libs = ["grpc++_reflection"]
+        self.cpp_info.components["grpc++_reflection"].system_libs = system_libs
+        self.cpp_info.components["grpc++_reflection"].requires = ["protobuf::libprotobuf", "grpc++", "libgrpc", "gpr", "upb"]
+
+        self.cpp_info.components["grpc++_unsecure"].libs = ["grpc++_unsecure"]
+        self.cpp_info.components["grpc++_unsecure"].system_libs = system_libs
+        self.cpp_info.components["grpc++_unsecure"].requires = ["protobuf::libprotobuf", "grpc++", "libgrpc", "gpr", "upb"]
+
+        # TODO: add optional plugin components?

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -10,50 +10,85 @@ endif()
 set(CMAKE_CXX_STANDARD 11)
 
 # Find Protobuf installation
-
 set(protobuf_MODULE_COMPATIBLE TRUE)
 find_package(protobuf CONFIG REQUIRED)
 message(STATUS "Using protobuf ${protobuf_VERSION}")
 
-set(_PROTOBUF_LIBPROTOBUF protobuf::libprotobuf)
-# set(_PROTOBUF_PROTOC $<TARGET_FILE:protobuf::protoc>)
-find_program(_PROTOBUF_PROTOC protoc ${CONAN_BIN_DIRS_PROTOBUF} NO_DEFAULT_PATH)
+# TODO: is this ok for cross-compile? CONAN_BIN_DIRS_PROTOBUF build or host context?
+find_program(PROTOC_PROGRAM protoc ${CONAN_BIN_DIRS_PROTOBUF} NO_DEFAULT_PATH)
+message(STATUS "Using protoc ${PROTOC_PROGRAM}")
 
 # Find gRPC installation
 find_package(gRPC CONFIG REQUIRED)
-# find_package(protoc CONFIG REQUIRED)
 message(STATUS "Using gRPC ${gRPC_VERSION}")
 
-set(_GRPC_CPP_PLUGIN_EXECUTABLE $<TARGET_FILE:gRPC::grpc_cpp_plugin>)
+function(protobuf_generate_grpc_cpp SRCS HDRS)
+    if(NOT ARGN)
+        message(SEND_ERROR "Error: protobuf_generate_grpc_cpp() called without any proto files")
+        return()
+    endif()
 
-# Proto file
-get_filename_component(hw_proto "helloworld.proto" ABSOLUTE)
-get_filename_component(hw_proto_path "${hw_proto}" PATH)
+    if (PROTOBUF_GENERATE_CPP_APPEND_PATH) # This variable is common for all types of output.
+        # Create an include path for each file specified
+        foreach(FIL ${ARGN})
+            get_filename_component(ABS_FIL ${FIL} ABSOLUTE)
+            get_filename_component(ABS_PATH ${ABS_FIL} PATH)
+            list(FIND _protobuf_include_path ${ABS_PATH} _contains_already)
+            if(${_contains_already} EQUAL -1)
+                list(APPEND _protobuf_include_path -I${ABS_PATH})
+            endif()
+        endforeach()
+    else()
+        set(_protobuf_include_path -I${CMAKE_CURRENT_SOURCE_DIR})
+    endif()
 
-# Generated sources
-set(hw_proto_srcs "${CMAKE_CURRENT_BINARY_DIR}/helloworld.pb.cc")
-set(hw_proto_hdrs "${CMAKE_CURRENT_BINARY_DIR}/helloworld.pb.h")
-set(hw_grpc_srcs "${CMAKE_CURRENT_BINARY_DIR}/helloworld.grpc.pb.cc")
-set(hw_grpc_hdrs "${CMAKE_CURRENT_BINARY_DIR}/helloworld.grpc.pb.h")
-add_custom_command(
-      OUTPUT "${hw_proto_srcs}" "${hw_proto_hdrs}" "${hw_grpc_srcs}" "${hw_grpc_hdrs}"
-      COMMAND ${_PROTOBUF_PROTOC}
-      ARGS --grpc_out "${CMAKE_CURRENT_BINARY_DIR}"
-        --cpp_out "${CMAKE_CURRENT_BINARY_DIR}"
-        -I "${hw_proto_path}"
-        --plugin=protoc-gen-grpc="${_GRPC_CPP_PLUGIN_EXECUTABLE}"
-        "${hw_proto}"
-      DEPENDS "${hw_proto}")
+    if (DEFINED PROTOBUF_IMPORT_DIRS)
+        foreach(DIR ${Protobuf_IMPORT_DIRS})
+            get_filename_component(ABS_PATH ${DIR} ABSOLUTE)
+            list(FIND _protobuf_include_path ${ABS_PATH} _contains_already)
+            if(${_contains_already} EQUAL -1)
+                list(APPEND _protobuf_include_path -I${ABS_PATH})
+            endif()
+        endforeach()
+    endif()
 
-# Build generated sources as an object library
-add_library(hw_proto_obj OBJECT ${hw_proto_srcs} ${hw_grpc_srcs})
+    find_program(GRPC_CPP_PLUGIN grpc_cpp_plugin) # Get full path to plugin
+    if (NOT GRPC_CPP_PLUGIN)
+        message(SEND_ERROR "Error: grpc_cpp_plugin is required")
+        return()
+    endif()
 
-# Include generated *.pb.h files
-include_directories("${CMAKE_CURRENT_BINARY_DIR}")
+    set(${SRCS})
+    set(${HDRS})
+    foreach(FIL ${ARGN})
+        get_filename_component(ABS_FIL ${FIL} ABSOLUTE)
+        get_filename_component(FIL_WE ${FIL} NAME_WE)
 
-# Targets greeter_[async_](client)
-foreach(_target greeter_client_server)
-# greeter_async_client greeter_async_server)
-  add_executable(${_target} "${_target}.cc" $<TARGET_OBJECTS:hw_proto_obj>)
-  target_link_libraries(${_target} gRPC::grpc++_unsecure)
-endforeach()
+        list(APPEND ${SRCS} "${CMAKE_CURRENT_BINARY_DIR}/${FIL_WE}.grpc.pb.cc")
+        list(APPEND ${HDRS} "${CMAKE_CURRENT_BINARY_DIR}/${FIL_WE}.grpc.pb.h")
+
+        add_custom_command(
+            OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${FIL_WE}.grpc.pb.cc"
+                   "${CMAKE_CURRENT_BINARY_DIR}/${FIL_WE}.grpc.pb.h"
+            COMMAND "${CMAKE_COMMAND}"  #FIXME: use conan binary component
+            ARGS -E env "DYLD_LIBRARY_PATH=${Protobuf_LIB_DIRS}:${CONAN_LIB_DIRS}:${Protobuf_LIB_DIRS_RELEASE}:${Protobuf_LIB_DIRS_DEBUG}:${Protobuf_LIB_DIRS_RELWITHDEBINFO}:${Protobuf_LIB_DIRS_MINSIZEREL}"
+                 ${PROTOC_PROGRAM}
+                 --grpc_out=${CMAKE_CURRENT_BINARY_DIR}
+                 --plugin=protoc-gen-grpc=${GRPC_CPP_PLUGIN}
+                 ${_protobuf_include_path} ${ABS_FIL}
+            DEPENDS ${ABS_FIL} ${PROTOC_PROGRAM}
+            COMMENT "Running gRPC cpp protocol buffer compiler on ${FIL}"
+            VERBATIM)
+    endforeach()
+
+    set_source_files_properties(${${SRCS}} ${${HDRS}} PROPERTIES GENERATED TRUE)
+    set(${SRCS} ${${SRCS}} PARENT_SCOPE)
+    set(${HDRS} ${${HDRS}} PARENT_SCOPE)
+endfunction()
+
+protobuf_generate_cpp(hw_proto_srcs hw_proto_hdrs helloworld.proto)
+protobuf_generate_grpc_cpp(hw_grpc_srcs hw_grpc_hdrs helloworld.proto)
+
+add_executable(greeter_client_server greeter_client_server.cc ${hw_proto_srcs} ${hw_proto_hdrs} ${hw_grpc_srcs} ${hw_grpc_hdrs})
+target_include_directories(greeter_client_server PRIVATE ${CMAKE_BINARY_DIR})
+target_link_libraries(greeter_client_server PRIVATE gRPC::grpc++_unsecure)


### PR DESCRIPTION
Adding components on top of 1.31.1 version

Tested with

```
[settings]
os=Macos
os_build=Macos
arch=x86_64
arch_build=x86_64
compiler=apple-clang
compiler.version=12.0
compiler.libcxx=libc++
build_type=Release
[options]
[build_requires]
[env]
```

TODO:
 - grpc_cronet is listed in the old list of libraries but I cant find it after installation.
 - test on more platforms (especially with shared=True)
 - should gRPC support Protobuf:lite=True?
 - component names must have 'lib' on Linux? I've seen this on the old commit https://github.com/inexorgame/conan-grpc/commit/7d066863367781c7c20c16cdcacbe41efb429c59
