### PR TITLE
Enable cross building for Android and iOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,11 +4,11 @@ project(cmake_wrapper)
 include(conanbuildinfo.cmake)
 conan_basic_setup()
 
-if(NOT PROTOC_PROGRAM)
-    message(FATAL_ERROR "Expected Conan to provide: 'PROTOC_PROGRAM'")
+if(NOT Protobuf_PROTOC_EXECUTABLE)
+    message(FATAL_ERROR "Expected Conan to provide: 'Protobuf_PROTOC_EXECUTABLE'")
 endif()
 # GRPC will find the wrong protoc when cross building.
 # Override it here.
-set(_gRPC_PROTOBUF_PROTOC_EXECUTABLE ${PROTOC_PROGRAM})
+set(_gRPC_PROTOBUF_PROTOC_EXECUTABLE ${Protobuf_PROTOC_EXECUTABLE})
 
 add_subdirectory("source_subfolder")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,10 @@
 cmake_minimum_required(VERSION 2.8.12)
 project(cmake_wrapper)
 
+# Need to find protoc before conan setup to make sure we get the correct
+# one when cross compiling.
+find_program(_gRPC_PROTOBUF_PROTOC_EXECUTABLE protoc)
+
 include(conanbuildinfo.cmake)
 conan_basic_setup()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,14 @@
 cmake_minimum_required(VERSION 2.8.12)
 project(cmake_wrapper)
 
-# Need to find protoc before conan setup to make sure we get the correct
-# one when cross compiling.
-find_program(_gRPC_PROTOBUF_PROTOC_EXECUTABLE protoc)
-
 include(conanbuildinfo.cmake)
 conan_basic_setup()
+
+if(NOT PROTOC_PROGRAM)
+    message(FATAL_ERROR "Expected Conan to provide: 'PROTOC_PROGRAM'")
+endif()
+# GRPC will find the wrong protoc when cross building.
+# Override it here.
+set(_gRPC_PROTOBUF_PROTOC_EXECUTABLE ${PROTOC_PROGRAM})
 
 add_subdirectory("source_subfolder")

--- a/conandata.yml
+++ b/conandata.yml
@@ -32,3 +32,7 @@ sources:
   "1.34.1":
     url: https://github.com/grpc/grpc/archive/v1.34.1.zip
     sha256: 0884778ef7866c2aaa9c06abd820f2ba2b514edcc5ec21bda74f3b7253036f9d
+patches:
+  "1.34.1":
+    - patch_file: "patches/upstream-pr-24959-only-openssl-engine-when-supported.patch"
+      base_path: "source_subfolder"

--- a/conanfile.py
+++ b/conanfile.py
@@ -59,8 +59,7 @@ class grpcConan(ConanFile):
 
         # When cross building the recipe depends on itself to provide the plugins
         if tools.cross_building(self.settings):
-            self.build_requires(
-                f"{self.name}/{self.version}@{self.user}/{self.channel}")
+            self.build_requires("{}/{}@{}/{}".format(self.name, self.version, self.user, self.channel))
 
     def configure(self):
         if self.settings.os == "Windows" and self.settings.compiler == "Visual Studio":

--- a/patches/upstream-pr-24959-only-openssl-engine-when-supported.patch
+++ b/patches/upstream-pr-24959-only-openssl-engine-when-supported.patch
@@ -1,0 +1,51 @@
+commit e3918f40fb45dc569d8c068c179dd086b89bc938
+Author: jiangtaoli2016 <jiangtao@google.com>
+Date:   Thu Dec 10 08:51:25 2020 -0800
+
+    Only enable OpenSSL Engine when compiler supports it
+
+diff --git a/src/core/tsi/ssl_transport_security.cc b/src/core/tsi/ssl_transport_security.cc
+index ad9f5704bf..c6a8580021 100644
+--- a/src/core/tsi/ssl_transport_security.cc
++++ b/src/core/tsi/ssl_transport_security.cc
+@@ -141,7 +141,7 @@ struct tsi_ssl_frame_protector {
+ static gpr_once g_init_openssl_once = GPR_ONCE_INIT;
+ static int g_ssl_ctx_ex_factory_index = -1;
+ static const unsigned char kSslSessionIdContext[] = {'g', 'r', 'p', 'c'};
+-#ifndef OPENSSL_IS_BORINGSSL
++#if !defined(OPENSSL_IS_BORINGSSL) && !defined(OPENSSL_NO_ENGINE)
+ static const char kSslEnginePrefix[] = "engine:";
+ #endif
+ 
+@@ -592,7 +592,7 @@ static tsi_result ssl_ctx_use_certificate_chain(SSL_CTX* context,
+   return result;
+ }
+ 
+-#ifndef OPENSSL_IS_BORINGSSL
++#if !defined(OPENSSL_IS_BORINGSSL) && !defined(OPENSSL_NO_ENGINE)
+ static tsi_result ssl_ctx_use_engine_private_key(SSL_CTX* context,
+                                                  const char* pem_key,
+                                                  size_t pem_key_size) {
+@@ -665,7 +665,7 @@ static tsi_result ssl_ctx_use_engine_private_key(SSL_CTX* context,
+   if (engine_name != nullptr) gpr_free(engine_name);
+   return result;
+ }
+-#endif /* OPENSSL_IS_BORINGSSL */
++#endif /* !defined(OPENSSL_IS_BORINGSSL) && !defined(OPENSSL_NO_ENGINE) */
+ 
+ static tsi_result ssl_ctx_use_pem_private_key(SSL_CTX* context,
+                                               const char* pem_key,
+@@ -696,11 +696,11 @@ static tsi_result ssl_ctx_use_pem_private_key(SSL_CTX* context,
+ static tsi_result ssl_ctx_use_private_key(SSL_CTX* context, const char* pem_key,
+                                           size_t pem_key_size) {
+ // BoringSSL does not have ENGINE support
+-#ifndef OPENSSL_IS_BORINGSSL
++#if !defined(OPENSSL_IS_BORINGSSL) && !defined(OPENSSL_NO_ENGINE)
+   if (strncmp(pem_key, kSslEnginePrefix, strlen(kSslEnginePrefix)) == 0) {
+     return ssl_ctx_use_engine_private_key(context, pem_key, pem_key_size);
+   } else
+-#endif /* OPENSSL_IS_BORINGSSL */
++#endif /* !defined(OPENSSL_IS_BORINGSSL) && !defined(OPENSSL_NO_ENGINE) */
+   {
+     return ssl_ctx_use_pem_private_key(context, pem_key, pem_key_size);
+   }

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -1,15 +1,6 @@
 cmake_minimum_required(VERSION 3.1)
 project(test_package)
 
-# Need to find protoc before conan setup to make sure we get the correct
-# one when cross compiling.
-find_program(_PROTOBUF_PROTOC protoc REQUIRED)
-message("_PROTOBUF_PROTOC ${_PROTOBUF_PROTOC}")
-
-if(NOT _PROTOBUF_PROTOC)
-    message(FATAL_ERROR "${_PROTOBUF_PROTOC} but required!")
-endif()
-
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup()
 
@@ -19,10 +10,12 @@ endif()
 set(CMAKE_CXX_STANDARD 11)
 
 # Find Protobuf installation
-
 set(protobuf_MODULE_COMPATIBLE TRUE)
 find_package(protobuf CONFIG REQUIRED)
 message(STATUS "Using protobuf ${protobuf_VERSION}")
+if(NOT PROTOC_PROGRAM)
+    message(FATAL_ERROR "Expected Conan to provide: 'PROTOC_PROGRAM'")
+endif()
 
 set(_PROTOBUF_LIBPROTOBUF protobuf::libprotobuf)
 
@@ -47,7 +40,7 @@ set(hw_grpc_srcs "${CMAKE_CURRENT_BINARY_DIR}/helloworld.grpc.pb.cc")
 set(hw_grpc_hdrs "${CMAKE_CURRENT_BINARY_DIR}/helloworld.grpc.pb.h")
 add_custom_command(
       OUTPUT "${hw_proto_srcs}" "${hw_proto_hdrs}" "${hw_grpc_srcs}" "${hw_grpc_hdrs}"
-      COMMAND ${_PROTOBUF_PROTOC}
+      COMMAND ${PROTOC_PROGRAM}
       ARGS --grpc_out "${CMAKE_CURRENT_BINARY_DIR}"
         --cpp_out "${CMAKE_CURRENT_BINARY_DIR}"
         -I "${hw_proto_path}"

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -16,15 +16,24 @@ find_package(protobuf CONFIG REQUIRED)
 message(STATUS "Using protobuf ${protobuf_VERSION}")
 
 set(_PROTOBUF_LIBPROTOBUF protobuf::libprotobuf)
-# set(_PROTOBUF_PROTOC $<TARGET_FILE:protobuf::protoc>)
-find_program(_PROTOBUF_PROTOC protoc ${CONAN_BIN_DIRS_PROTOBUF} NO_DEFAULT_PATH)
+
+# Find protoc
+find_program(_PROTOBUF_PROTOC protoc REQUIRED)
+message("_PROTOBUF_PROTOC ${_PROTOBUF_PROTOC}")
+
+if(NOT _PROTOBUF_PROTOC)
+    message(FATAL_ERROR "${_PROTOBUF_PROTOC} but required!")
+endif()
 
 # Find gRPC installation
 find_package(gRPC CONFIG REQUIRED)
-# find_package(protoc CONFIG REQUIRED)
 message(STATUS "Using gRPC ${gRPC_VERSION}")
 
-set(_GRPC_CPP_PLUGIN_EXECUTABLE $<TARGET_FILE:gRPC::grpc_cpp_plugin>)
+# Find GRPC_CPP_PLUGIN_EXECUTABLE
+find_program(_GRPC_CPP_PLUGIN_EXECUTABLE grpc_cpp_plugin REQUIRED)
+if(NOT _GRPC_CPP_PLUGIN_EXECUTABLE)
+    message(FATAL_ERROR "${_GRPC_CPP_PLUGIN_EXECUTABLE} but required!")
+endif()
 
 # Proto file
 get_filename_component(hw_proto "helloworld.proto" ABSOLUTE)

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -13,8 +13,8 @@ set(CMAKE_CXX_STANDARD 11)
 set(protobuf_MODULE_COMPATIBLE TRUE)
 find_package(protobuf CONFIG REQUIRED)
 message(STATUS "Using protobuf ${protobuf_VERSION}")
-if(NOT PROTOC_PROGRAM)
-    message(FATAL_ERROR "Expected Conan to provide: 'PROTOC_PROGRAM'")
+if(NOT Protobuf_PROTOC_EXECUTABLE)
+    message(FATAL_ERROR "Expected Conan to provide: 'Protobuf_PROTOC_EXECUTABLE'")
 endif()
 
 set(_PROTOBUF_LIBPROTOBUF protobuf::libprotobuf)
@@ -40,7 +40,7 @@ set(hw_grpc_srcs "${CMAKE_CURRENT_BINARY_DIR}/helloworld.grpc.pb.cc")
 set(hw_grpc_hdrs "${CMAKE_CURRENT_BINARY_DIR}/helloworld.grpc.pb.h")
 add_custom_command(
       OUTPUT "${hw_proto_srcs}" "${hw_proto_hdrs}" "${hw_grpc_srcs}" "${hw_grpc_hdrs}"
-      COMMAND ${PROTOC_PROGRAM}
+      COMMAND ${Protobuf_PROTOC_EXECUTABLE}
       ARGS --grpc_out "${CMAKE_CURRENT_BINARY_DIR}"
         --cpp_out "${CMAKE_CURRENT_BINARY_DIR}"
         -I "${hw_proto_path}"

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -1,6 +1,15 @@
 cmake_minimum_required(VERSION 3.1)
 project(test_package)
 
+# Need to find protoc before conan setup to make sure we get the correct
+# one when cross compiling.
+find_program(_PROTOBUF_PROTOC protoc REQUIRED)
+message("_PROTOBUF_PROTOC ${_PROTOBUF_PROTOC}")
+
+if(NOT _PROTOBUF_PROTOC)
+    message(FATAL_ERROR "${_PROTOBUF_PROTOC} but required!")
+endif()
+
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup()
 
@@ -16,14 +25,6 @@ find_package(protobuf CONFIG REQUIRED)
 message(STATUS "Using protobuf ${protobuf_VERSION}")
 
 set(_PROTOBUF_LIBPROTOBUF protobuf::libprotobuf)
-
-# Find protoc
-find_program(_PROTOBUF_PROTOC protoc REQUIRED)
-message("_PROTOBUF_PROTOC ${_PROTOBUF_PROTOC}")
-
-if(NOT _PROTOBUF_PROTOC)
-    message(FATAL_ERROR "${_PROTOBUF_PROTOC} but required!")
-endif()
 
 # Find gRPC installation
 find_package(gRPC CONFIG REQUIRED)

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -6,6 +6,11 @@ class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
     generators = "cmake", "cmake_find_package_multi"
 
+    def build_requirements(self):
+        self.build_requires("protobuf/3.13.0")
+        if tools.cross_building(self.settings):
+            self.build_requires(str(self.requires['grpc']))
+
     def build(self):
         cmake = CMake(self)
         cmake.configure()


### PR DESCRIPTION
Allows grpc to be cross built using dual profiles (profile host/build).

Disables plugins when cross building and the recipe instead depends on itself to provide the plugins.

The patch is needed for the iOS build. Relates to OpenSSL stuff.
It's already fixed in master but not in 1.34.1. See https://github.com/grpc/grpc/pull/24959

Cross building for Android and iOS depends on this PR to protobuf: https://github.com/conan-io/conan-center-index/pull/4556
Cross building for iOS build also depends on this PR to c-ares: https://github.com/conan-io/conan-center-index/pull/4492

Tested on both Android and iOS:

Android profile:
```
Configuration (profile_host):
[settings]
arch=armv8
build_type=Release
compiler=clang
compiler.libcxx=c++_static
compiler.version=11
os=Android
os.api_level=21
[options]
[build_requires]
*: android-ndk/r22
[env]

Configuration (profile_build):
[settings]
arch=x86_64
build_type=Release
compiler=clang
compiler.libcxx=libstdc++
compiler.version=6.0
os=Linux
[options]
[build_requires]
[env]
CC=/usr/bin/clang
CXX=/usr/bin/clang++
```

iOS profile:
```
Configuration (profile_host):
[settings]
arch=armv8
build_type=Release
compiler=apple-clang
compiler.libcxx=libc++
compiler.version=11.0
os=iOS
os.version=10.2
[options]
ios-cmake:enable_bitcode=False
[build_requires]
*: ios-cmake/3.1.2
[env]

Configuration (profile_build):
[settings]
arch=x86_64
build_type=Release
compiler=apple-clang
compiler.libcxx=libc++
compiler.version=11.0
os=Macos
[options]
[build_requires]
[env]
``` 